### PR TITLE
Add support for iDQ in multi-IFO workflow

### DIFF
--- a/bin/workflows/pycbc_create_offline_search_workflow
+++ b/bin/workflows/pycbc_create_offline_search_workflow
@@ -136,10 +136,13 @@ ssegs = {}
 for ifo in workflow.ifos:
     ssegs[ifo] = science_seg_file.segment_dict["%s:science" % ifo]
 
+hoft_tags=[]
+if len(workflow.cp.get_subsections('workflow-datafind'))>0:
+    tags=['hoft']
 datafind_files, analyzable_file, analyzable_segs, analyzable_name = \
                                            wf.setup_datafind_workflow(workflow,
                                      ssegs, "datafind",
-                                     seg_file=science_seg_file)
+                                     seg_file=science_seg_file, tags=hoft_tags)
 
 final_veto_name = 'vetoes'
 final_veto_file = wf.get_segments_file(workflow, final_veto_name,
@@ -175,6 +178,8 @@ insps = wf.merge_single_detector_hdf_files(workflow, hdfbank,
 # setup sngl trigger distribution fitting jobs
 # 'statfiles' is list of files used in calculating coinc statistic
 statfiles = []
+statfiles += wf.setup_idq_reranking(workflow, analyzable_segs, 
+                                    analyzable_file, output_dir='idq')
 statfiles += wf.setup_trigger_fitting(workflow, insps, hdfbank,
                                       final_veto_file, final_veto_name,
                                       output_dir=output_dir,

--- a/bin/workflows/pycbc_create_offline_search_workflow
+++ b/bin/workflows/pycbc_create_offline_search_workflow
@@ -137,8 +137,9 @@ for ifo in workflow.ifos:
     ssegs[ifo] = science_seg_file.segment_dict["%s:science" % ifo]
 
 hoft_tags=[]
-if len(workflow.cp.get_subsections('workflow-datafind'))>0:
-    tags=['hoft']
+#if len(workflow.cp.get_subsections('workflow-datafind'))>0:
+if 'hoft' in workflow.cp.get_subsections('workflow-datafind'):
+    hoft_tags=['hoft']
 datafind_files, analyzable_file, analyzable_segs, analyzable_name = \
                                            wf.setup_datafind_workflow(workflow,
                                      ssegs, "datafind",

--- a/pycbc/workflow/idq.py
+++ b/pycbc/workflow/idq.py
@@ -52,7 +52,7 @@ class PyCBCRerankiDQExecutable(Executable):
 def setup_idq_reranking(workflow, segs, analyzable_file, output_dir=None, tags=None):
     if not workflow.cp.has_option('workflow-coincidence', 'do-idq-fitting'):
         return FileList()
-    else:
+    elif 'idq' in workflow.cp.get_subsections('workflow-datafind'):
         datafind_files, idq_file, idq_segs, idq_name = \
                                            setup_datafind_workflow(workflow,
                                            segs, "datafind_idq",
@@ -78,5 +78,13 @@ def setup_idq_reranking(workflow, segs, analyzable_file, output_dir=None, tags=N
             new_node = new_exe.create_node(ifo, idq_files)
             workflow += new_node
             output += new_node.output_files
+    else:
+        msg = """No workflow-datafind section with idq tag.
+              Tags must be used in workflow-datafind sections "
+              if more than one source of data is used.
+              Strain data source must be tagged 
+              workflow-datafind-hoft.
+              Consult the documentation for more info."""
+        raise ValueError(msg)
                
         return output


### PR DESCRIPTION
This PR adds support to include IDQ information in the mutli-IFO workflow executable. Implementation is almost identical to two IFO workflow implantation. 

Note that there is currently not support for including iDQ information in a subset of IFOs. 